### PR TITLE
chore: Enhance Makefile with additional development targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install install-dev format lint test test-cov test-integration clean build publish help pre-commit
+.PHONY: all install install-dev format lint typecheck test test-cov test-property test-integration test-all clean build publish docs docs-build pre-commit benchmark help
 
 PYTHON ?= python
 UV ?= uv
@@ -11,26 +11,36 @@ help:
 	@echo "  make install-dev      Install package with dev dependencies"
 	@echo "  make format           Format code with ruff"
 	@echo "  make lint             Run linters (ruff + mypy)"
+	@echo "  make typecheck        Run mypy type checking"
 	@echo "  make test             Run unit tests"
 	@echo "  make test-cov         Run tests with coverage"
+	@echo "  make test-property    Run property-based tests"
 	@echo "  make test-integration Run integration tests (requires Snowflake)"
+	@echo "  make test-all         Run lint, unit tests, and property tests"
 	@echo "  make pre-commit       Install and run pre-commit hooks"
 	@echo "  make clean            Clean build artifacts"
 	@echo "  make build            Build package"
 	@echo "  make publish          Publish to PyPI"
+	@echo "  make docs             Serve documentation locally"
+	@echo "  make docs-build       Build documentation"
+	@echo "  make benchmark        Run benchmarks"
 
 install:
 	$(UV) pip install -e .
 
 install-dev:
 	$(UV) pip install -e ".[dev]"
+	pre-commit install
 
 format:
 	ruff format src tests
 	ruff check --fix src tests
 
-lint:
+lint: typecheck
 	ruff check src tests
+	ruff format --check src tests
+
+typecheck:
 	mypy src/langgraph_checkpoint_snowflake
 
 test:
@@ -39,8 +49,13 @@ test:
 test-cov:
 	pytest tests -v --cov=src/langgraph_checkpoint_snowflake --cov-report=html --cov-report=term-missing --ignore=tests/test_integration.py
 
+test-property:
+	pytest tests/test_property.py -v --hypothesis-seed=0
+
 test-integration:
 	pytest tests -v -m integration
+
+test-all: lint test test-property
 
 pre-commit:
 	pre-commit install
@@ -56,6 +71,7 @@ clean:
 	rm -rf .ruff_cache/
 	rm -rf htmlcov/
 	rm -rf .coverage
+	rm -rf coverage.xml
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
 
@@ -64,3 +80,15 @@ build: clean
 
 publish: build
 	$(PYTHON) -m twine upload dist/*
+
+docs:
+	mkdocs serve
+
+docs-build:
+	mkdocs build
+
+benchmark:
+	$(PYTHON) -c "from langgraph_checkpoint_snowflake import SnowflakeSaver; \
+		with SnowflakeSaver.from_env() as s: \
+			s.setup(); \
+			for k, v in s.benchmark(iterations=20).items(): print(v)"


### PR DESCRIPTION
## Summary

Enhances the existing Makefile with missing development targets that are referenced in README and CONTRIBUTING.md but were not available.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #20

## Changes Made

- Added `typecheck` as a standalone target (runs `mypy` independently)
- Made `lint` depend on `typecheck` and added `ruff format --check` for format verification
- Added `test-property` target for hypothesis-based property tests
- Added `test-all` target combining `lint`, `test`, and `test-property`
- Added `docs` and `docs-build` targets for mkdocs
- Added `benchmark` target for performance benchmarking
- Added `pre-commit install` to `install-dev` target
- Added `coverage.xml` to `clean` target
- Updated `help` output to list all new targets

## Testing

- [x] Manual testing performed

`make help` output now shows all available targets.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] `make help` shows all available targets
- [x] README commands now correspond to actual Makefile targets