### PR TITLE
chore: Add .editorconfig and .gitattributes for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# .editorconfig
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{json,toml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# .gitattributes
+* text=auto eol=lf
+*.py text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.sh text eol=lf
+*.toml text eol=lf
+*.json text eol=lf


### PR DESCRIPTION
## Summary

Adds `.editorconfig` and `.gitattributes` to enforce consistent editor settings and line endings across all contributors.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #18

## Changes Made

- Created `.editorconfig` with settings matching project conventions:
  - 4-space indentation for Python files
  - 2-space indentation for YAML, JSON, and TOML files
  - Tab indentation for Makefile
  - LF line endings and UTF-8 charset
  - Trailing whitespace trimming (except Markdown, which uses trailing spaces for line breaks)
- Created `.gitattributes` to enforce LF line endings across platforms

## Testing

- [x] Manual testing performed

Verified settings match existing code style (ruff config uses 4-space indent for Python, YAML files use 2-space).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Settings match project conventions (4 spaces for Python, 2 for YAML)